### PR TITLE
New 'dvd pull' action in Gold Image Processing Workflow command

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -413,7 +413,7 @@ watch = ["pyinotify"]
 
 [[package]]
 name = "dvc"
-version = "2.9.2"
+version = "2.9.3"
 description = "Git for data scientists - manage your code and data together"
 category = "main"
 optional = false
@@ -450,7 +450,7 @@ python-benedict = ">=0.24.2"
 requests = ">=2.22.0"
 rich = ">=10.13.0"
 "ruamel.yaml" = ">=0.17.11"
-scmrepo = "0.0.4"
+scmrepo = "0.0.7"
 shortuuid = ">=0.5.0"
 shtab = ">=1.3.4,<2"
 tabulate = ">=0.8.7"
@@ -461,20 +461,20 @@ voluptuous = ">=0.11.7"
 "zc.lockfile" = ">=1.2.1"
 
 [package.extras]
-all = ["adlfs (>=2021.10.0)", "azure-identity (>=1.4.0)", "knack", "pydrive2[fsspec] (>=1.9.4)", "gcsfs (>=2021.11.1)", "fsspec", "ossfs (>=2021.8.0)", "s3fs (>=2021.11.1)", "aiobotocore[boto3] (>1.0.1)", "sshfs[bcrypt] (>=2021.11.2)", "webdav4 (>=0.9.3)"]
+all = ["adlfs (>=2021.10.0)", "azure-identity (>=1.4.0)", "knack", "pydrive2[fsspec] (>=1.9.4)", "gcsfs (>=2021.11.1)", "pyarrow (>=1)", "fsspec", "ossfs (>=2021.8.0)", "s3fs[boto3] (>=2021.11.1)", "bcrypt", "sshfs[bcrypt] (>=2021.11.2)", "webdav4 (>=0.9.3)"]
 azure = ["adlfs (>=2021.10.0)", "azure-identity (>=1.4.0)", "knack"]
-dev = ["adlfs (>=2021.10.0)", "azure-identity (>=1.4.0)", "knack", "pydrive2[fsspec] (>=1.9.4)", "gcsfs (>=2021.11.1)", "fsspec", "ossfs (>=2021.8.0)", "s3fs (>=2021.11.1)", "aiobotocore[boto3] (>1.0.1)", "sshfs[bcrypt] (>=2021.11.2)", "webdav4 (>=0.9.3)", "tpi[ssh] (>=2.1.0)", "wheel (==0.37.0)", "dvc-ssh (==0.0.1a0)", "pytest (==6.2.5)", "pytest-cov (==3.0.0)", "pytest-xdist (==2.4.0)", "pytest-mock (==3.6.1)", "pytest-lazy-fixture (==0.6.3)", "flaky (==3.7.0)", "mock (==4.0.3)", "pytest-timeout (==2.0.1)", "rangehttpserver (==1.2.0)", "mock-ssh-server (==0.9.1)", "wget (==3.2)", "filelock (==3.4.0)", "wsgidav (==3.1.1)", "crc32c (==2.2.post0)", "xmltodict (==0.12.0)", "google-compute-engine (==2.8.13)", "google-cloud-storage (==1.43.0)", "dvclive[image] (==0.4.6)", "hdfs (==2.6.0)", "Pygments (==2.10.0)", "collective.checkdocs (==0.2)", "pydocstyle (==6.1.1)", "pylint (==2.12.2)", "pylint-pytest (==1.1.2)", "pylint-plugin-utils (==0.6)", "mypy (==0.910)", "types-requests (==2.26.1)", "types-tabulate (==0.8.3)", "types-toml (==0.10.1)", "pytest-docker (==0.10.3)", "pywin32 (>=225)"]
+dev = ["adlfs (>=2021.10.0)", "azure-identity (>=1.4.0)", "knack", "pydrive2[fsspec] (>=1.9.4)", "gcsfs (>=2021.11.1)", "pyarrow (>=1)", "fsspec", "ossfs (>=2021.8.0)", "s3fs[boto3] (>=2021.11.1)", "bcrypt", "sshfs[bcrypt] (>=2021.11.2)", "webdav4 (>=0.9.3)", "tpi[ssh] (>=2.1.0)", "wheel (==0.37.0)", "dvc-ssh (==0.0.1a0)", "pytest (==6.2.5)", "pytest-cov (==3.0.0)", "pytest-xdist (==2.5.0)", "pytest-mock (==3.6.1)", "pytest-lazy-fixture (==0.6.3)", "flaky (==3.7.0)", "mock (==4.0.3)", "pytest-timeout (==2.0.2)", "rangehttpserver (==1.2.0)", "mock-ssh-server (==0.9.1)", "wget (==3.2)", "filelock (==3.4.0)", "wsgidav (==3.1.1)", "crc32c (==2.2.post0)", "xmltodict (==0.12.0)", "google-compute-engine (==2.8.13)", "google-cloud-storage (==1.43.0)", "dvclive[image] (==0.4.6)", "hdfs (==2.6.0)", "Pygments (==2.10.0)", "collective.checkdocs (==0.2)", "pydocstyle (==6.1.1)", "pylint (==2.12.2)", "pylint-pytest (==1.1.2)", "pylint-plugin-utils (==0.6)", "mypy (==0.921)", "types-requests (==2.26.2)", "types-tabulate (==0.8.3)", "types-toml (==0.10.1)", "pytest-docker (==0.10.3)", "pywin32 (>=225)"]
 gdrive = ["pydrive2[fsspec] (>=1.9.4)"]
 gs = ["gcsfs (>=2021.11.1)"]
-hdfs = ["fsspec"]
+hdfs = ["pyarrow (>=1)", "fsspec"]
 oss = ["ossfs (>=2021.8.0)"]
-s3 = ["s3fs (>=2021.11.1)", "aiobotocore[boto3] (>1.0.1)"]
-ssh = ["sshfs[bcrypt] (>=2021.11.2)"]
+s3 = ["s3fs[boto3] (>=2021.11.1)"]
+ssh = ["bcrypt", "sshfs[bcrypt] (>=2021.11.2)"]
 ssh_gssapi = ["sshfs[gssapi] (>=2021.11.2)"]
 terraform = ["tpi[ssh] (>=2.1.0)"]
-tests = ["tpi[ssh] (>=2.1.0)", "wheel (==0.37.0)", "dvc-ssh (==0.0.1a0)", "pytest (==6.2.5)", "pytest-cov (==3.0.0)", "pytest-xdist (==2.4.0)", "pytest-mock (==3.6.1)", "pytest-lazy-fixture (==0.6.3)", "flaky (==3.7.0)", "mock (==4.0.3)", "pytest-timeout (==2.0.1)", "rangehttpserver (==1.2.0)", "mock-ssh-server (==0.9.1)", "wget (==3.2)", "filelock (==3.4.0)", "wsgidav (==3.1.1)", "crc32c (==2.2.post0)", "xmltodict (==0.12.0)", "google-compute-engine (==2.8.13)", "google-cloud-storage (==1.43.0)", "dvclive[image] (==0.4.6)", "hdfs (==2.6.0)", "Pygments (==2.10.0)", "collective.checkdocs (==0.2)", "pydocstyle (==6.1.1)", "pylint (==2.12.2)", "pylint-pytest (==1.1.2)", "pylint-plugin-utils (==0.6)", "mypy (==0.910)", "types-requests (==2.26.1)", "types-tabulate (==0.8.3)", "types-toml (==0.10.1)", "pytest-docker (==0.10.3)", "pywin32 (>=225)"]
+tests = ["tpi[ssh] (>=2.1.0)", "wheel (==0.37.0)", "dvc-ssh (==0.0.1a0)", "pytest (==6.2.5)", "pytest-cov (==3.0.0)", "pytest-xdist (==2.5.0)", "pytest-mock (==3.6.1)", "pytest-lazy-fixture (==0.6.3)", "flaky (==3.7.0)", "mock (==4.0.3)", "pytest-timeout (==2.0.2)", "rangehttpserver (==1.2.0)", "mock-ssh-server (==0.9.1)", "wget (==3.2)", "filelock (==3.4.0)", "wsgidav (==3.1.1)", "crc32c (==2.2.post0)", "xmltodict (==0.12.0)", "google-compute-engine (==2.8.13)", "google-cloud-storage (==1.43.0)", "dvclive[image] (==0.4.6)", "hdfs (==2.6.0)", "Pygments (==2.10.0)", "collective.checkdocs (==0.2)", "pydocstyle (==6.1.1)", "pylint (==2.12.2)", "pylint-pytest (==1.1.2)", "pylint-plugin-utils (==0.6)", "mypy (==0.921)", "types-requests (==2.26.2)", "types-tabulate (==0.8.3)", "types-toml (==0.10.1)", "pytest-docker (==0.10.3)", "pywin32 (>=225)"]
 webdav = ["webdav4 (>=0.9.3)"]
-webhdfs = ["requests-kerberos (==0.14.0)"]
+webdhfs_kerberos = ["requests-kerberos (==0.14.0)"]
 
 [[package]]
 name = "flatten-dict"
@@ -1312,7 +1312,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "scmrepo"
-version = "0.0.4"
+version = "0.0.7"
 description = "SCM wrapper and fsspec filesystem for Git for use in DVC"
 category = "main"
 optional = false
@@ -1329,7 +1329,7 @@ pygit2 = ">=1.5.0"
 pygtrie = ">=2.3.2"
 
 [package.extras]
-dev = ["pytest (==6.2.5)", "pytest-sugar (==0.9.4)", "pytest-test-utils (==0.0.5)", "pytest-cov (==3.0.0)", "pytest-mock (==3.6.1)", "pylint (==2.11.1)", "mypy (==0.910)", "types-certifi (==2021.10.8.0)", "types-paramiko (==2.8.1)"]
+dev = ["pytest (==6.2.5)", "pytest-sugar (==0.9.4)", "pytest-test-utils (==0.0.6)", "pytest-cov (==3.0.0)", "pytest-mock (==3.6.1)", "pytest-asyncio (==0.16.0)", "pylint (==2.11.1)", "mypy (==0.910)", "paramiko (==2.8.1)", "types-certifi (==2021.10.8.0)", "types-paramiko (==2.8.1)", "pytest-docker (==0.10.3)"]
 
 [[package]]
 name = "shellingham"
@@ -1543,7 +1543,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "6568b7ac3ce39315f62bc12ac18ee4874e23e9e87198dd91bb77ef514c996aba"
+content-hash = "97e82df7bb41540a24cc73c79d4c5e9b69ec71f74b849aa4b9c823799e91bf2d"
 
 [metadata.files]
 adal = [
@@ -1877,8 +1877,8 @@ dulwich = [
     {file = "dulwich-0.20.26.tar.gz", hash = "sha256:38aa50f859c8ea53071a049c3f1d5cc54f7dc60a4136a1ab631756a79f6582b5"},
 ]
 dvc = [
-    {file = "dvc-2.9.2-py3-none-any.whl", hash = "sha256:555b4f1f86ddf03679320b81a6e3f67786cee8f5b61768acd490eda826758cef"},
-    {file = "dvc-2.9.2.tar.gz", hash = "sha256:543257907a843952c44bdb1ea84f2ae33d8693584c1175eb49eb95da0c2a2e49"},
+    {file = "dvc-2.9.3-py3-none-any.whl", hash = "sha256:00b22a912d93c26ab4a26362c1222ec47d86df524c78947e58ce9ffbba9d8685"},
+    {file = "dvc-2.9.3.tar.gz", hash = "sha256:513d0d9ee3c3123e616f760eb8556ee569121286c3e400a1fe4b3bf66e6dea29"},
 ]
 flatten-dict = [
     {file = "flatten-dict-0.4.2.tar.gz", hash = "sha256:506a96b6e6f805b81ae46a0f9f31290beb5fa79ded9d80dbe1b7fa236ab43076"},
@@ -2517,8 +2517,8 @@ rich = [
     {file = "ruamel.yaml.clib-0.2.6.tar.gz", hash = "sha256:4ff604ce439abb20794f05613c374759ce10e3595d1867764dd1ae675b85acbd"},
 ]
 scmrepo = [
-    {file = "scmrepo-0.0.4-py3-none-any.whl", hash = "sha256:cbb03fd15814fd5a7bb522dde9eab112742029eb6294bca6c28da73bffa77cf1"},
-    {file = "scmrepo-0.0.4.tar.gz", hash = "sha256:e00a46f1c5f560c35bafd792fd14b07144e1a2d1c384e20ab44a25f5f1d7c335"},
+    {file = "scmrepo-0.0.7-py3-none-any.whl", hash = "sha256:c80a23d5cbab62a9e2369cfc6cb739e2f008ed04259f403b2c56d196951319a9"},
+    {file = "scmrepo-0.0.7.tar.gz", hash = "sha256:0dd8ac0e0ca8223d5b2efacb77b2cb49ec3cc383241cc69d1ef7595736a4b0a9"},
 ]
 shellingham = [
     {file = "shellingham-1.4.0-py2.py3-none-any.whl", hash = "sha256:536b67a0697f2e4af32ab176c00a50ac2899c5a05e0d8e2dadac8e58888283f9"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ typer = {extras = ["all"], version = "^0.4.0"}
 mypy = "^0.910"
 atoml = "^1.1.1"
 python-gnupg = "^0.4.8"
+Deprecated = "^1.2.13"
 
 [tool.poetry.dev-dependencies]
 black = "^21.11b1"

--- a/src/nautilus_librarian/mods/dvc/domain/utils.py
+++ b/src/nautilus_librarian/mods/dvc/domain/utils.py
@@ -99,6 +99,14 @@ def extract_added_files_from_dvc_diff(dvc_diff):
     return [(path_object["path"]) for path_object in data["added"]]
 
 
+def dvc_default_remote(git_repo_dir):
+    """
+    It returns the default remote for the dvc repo.
+    """
+    output = execute_console_command("dvc remote default --project", cwd=git_repo_dir)
+    return output.strip()
+
+
 @deprecated(reason="use DvcApiWrapper class")
 def dvc_add(filepath, git_repo_dir):
     """

--- a/src/nautilus_librarian/mods/dvc/domain/utils.py
+++ b/src/nautilus_librarian/mods/dvc/domain/utils.py
@@ -1,6 +1,8 @@
 import json
 import os
 
+from deprecated import deprecated
+
 from nautilus_librarian.mods.console.domain.utils import execute_console_command
 
 
@@ -38,6 +40,30 @@ def extract_added_and_modified_and_renamed_files_from_dvc_diff(
     return filepaths
 
 
+def extract_added_and_modified_files_from_dvc_diff(dvc_diff, only_basename=True):
+    """
+    It gets a plain string list with the added and modified files from the dvc diff json.
+
+    With only_basename=True
+    Input: {"added": [{"path": "data/000001/32/000001-32.600.2.tif"}], "deleted": [], "modified": [], "renamed": []}
+    Output: ['000001-32.600.2.tif']
+
+    only_basename=False
+    Input: {"added": [{"path": "data/000001/32/000001-32.600.2.tif"}], "deleted": [], "modified": [], "renamed": []}
+    Output: ['data/000001/32/000001-32.600.2.tif']
+    """
+
+    data = json.loads(dvc_diff)
+
+    filepath_objects = data["added"] + data["modified"]
+    filepaths = [path_object["path"] for path_object in filepath_objects]
+
+    if only_basename:
+        filepaths = extract_basenames_from_filepaths(filepaths)
+
+    return filepaths
+
+
 def extract_list_of_media_file_changes_from_dvc_diff_output(
     dvc_diff, only_basename=True
 ):
@@ -46,6 +72,7 @@ def extract_list_of_media_file_changes_from_dvc_diff_output(
     )
 
 
+@deprecated(reason="use DvcApiWrapper class")
 def extract_added_files_from_dvc_diff(dvc_diff):
     """
     Parses the list of added Gold images from dvc diff output in json format.
@@ -72,6 +99,7 @@ def extract_added_files_from_dvc_diff(dvc_diff):
     return [(path_object["path"]) for path_object in data["added"]]
 
 
+@deprecated(reason="use DvcApiWrapper class")
 def dvc_add(filepath, git_repo_dir):
     """
     Wrapper for dvc add command.
@@ -82,6 +110,7 @@ def dvc_add(filepath, git_repo_dir):
     return execute_console_command(f"dvc add {filepath}", cwd=git_repo_dir)
 
 
+@deprecated(reason="use DvcApiWrapper class")
 def dvc_push(filepath, git_repo_dir):
     """
     Wrapper for dvc push command.
@@ -90,3 +119,11 @@ def dvc_push(filepath, git_repo_dir):
     https://github.com/Nautilus-Cyberneering/nautilus-librarian/pull/25
     """
     return execute_console_command(f"dvc push {filepath}", cwd=git_repo_dir)
+
+
+@deprecated(reason="use DvcApiWrapper class")
+def dvc_diff(a_rev, b_rev, git_repo_dir):
+    dvc_diff_output = execute_console_command(
+        f"dvc diff --show-json {a_rev} {b_rev}", cwd=git_repo_dir
+    )
+    return json.loads(dvc_diff_output)

--- a/src/nautilus_librarian/mods/git/domain/config.py
+++ b/src/nautilus_librarian/mods/git/domain/config.py
@@ -21,3 +21,15 @@ def git_config_global_user():
     ).strip()
 
     return GitUser(name, email, signingkey)
+
+
+def default_git_user_name():
+    git_config_global_user().name
+
+
+def default_git_user_email():
+    git_config_global_user().email
+
+
+def default_git_user_signingkey():
+    git_config_global_user().signingkey

--- a/src/nautilus_librarian/typer/commands/workflows/actions/auto_commit_base_images.py
+++ b/src/nautilus_librarian/typer/commands/workflows/actions/auto_commit_base_images.py
@@ -143,7 +143,7 @@ def auto_commit_base_images(dvc_diff, git_repo_dir, gnupghome, git_user: GitUser
 
         messages.append(
             Message(
-                f"New Gold image found: {gold_image} -> Base image: {base_img_relative_path} ✓ "
+                f"New Gold image found: {gold_image} -> Base image: {base_img_relative_path} ✓"
             )
         )
 

--- a/src/nautilus_librarian/typer/commands/workflows/actions/dvc_pull_action.py
+++ b/src/nautilus_librarian/typer/commands/workflows/actions/dvc_pull_action.py
@@ -1,0 +1,45 @@
+from nautilus_librarian.mods.dvc.domain.api import DvcApiWrapper
+from nautilus_librarian.mods.dvc.domain.utils import (
+    extract_added_and_modified_files_from_dvc_diff,
+)
+from nautilus_librarian.typer.commands.workflows.actions.action_result import (
+    ActionResult,
+    ErrorMessage,
+    Message,
+    ResultCode,
+)
+
+
+def dvc_pull_action(dvc_diff, git_repo_dir, remote_name):
+    """
+    It pulls from the dvc remote storage
+    all the added or modified library media files in the dvd diff.
+    """
+    if dvc_diff == "{}":
+        return ActionResult(ResultCode.EXIT, [Message("No Gold image changes found")])
+
+    filenames = extract_added_and_modified_files_from_dvc_diff(
+        dvc_diff, only_basename=False
+    )
+
+    dvcApiWrapper = DvcApiWrapper(git_repo_dir)
+
+    messages = []
+
+    for filename in filenames:
+        try:
+            # dvc pull --remote azure data/000000/32/000000-32.600.2.tif
+            dvcApiWrapper.pull(filename, remote_name)
+
+            messages.append(Message(f"✓ {filename} pulled from dvc storage"))
+        except ValueError as error:
+            return ActionResult(
+                ResultCode.ABORT,
+                [
+                    ErrorMessage(
+                        f"✗ Error pulling the file {filename} from DVC storage. {error}"
+                    )
+                ],
+            )
+
+    return ActionResult(ResultCode.CONTINUE, messages)

--- a/src/nautilus_librarian/typer/commands/workflows/gold_images_processing.py
+++ b/src/nautilus_librarian/typer/commands/workflows/gold_images_processing.py
@@ -7,6 +7,9 @@ from nautilus_librarian.typer.commands.workflows.actions.action_result import Re
 from nautilus_librarian.typer.commands.workflows.actions.auto_commit_base_images import (
     auto_commit_base_images,
 )
+from nautilus_librarian.typer.commands.workflows.actions.dvc_pull_action import (
+    dvc_pull_action,
+)
 from nautilus_librarian.typer.commands.workflows.actions.validate_filenames import (
     validate_filenames,
 )
@@ -86,6 +89,10 @@ def gold_images_processing(
     process_action_result(validate_filenames(dvc_diff))
 
     process_action_result(validate_filepaths_action(dvc_diff))
+
+    remote = "localremote"
+
+    process_action_result(dvc_pull_action(dvc_diff, git_repo_dir, remote))
 
     process_action_result(
         auto_commit_base_images(dvc_diff, git_repo_dir, gnupghome, git_user)

--- a/tests/test_nautilus_librarian/test_typer/test_commands/test_workflows/fixtures/workflows_fixtures.py
+++ b/tests/test_nautilus_librarian/test_typer/test_commands/test_workflows/fixtures/workflows_fixtures.py
@@ -31,3 +31,9 @@ def git_user(gpg_signing_key_info):
 def sample_base_image_absolute_path(workflows_fixtures_dir):
     base_image_path = f"{workflows_fixtures_dir}/images/000001-42.600.2.tif"
     return base_image_path
+
+
+@pytest.fixture(scope="session")
+def sample_gold_image_absolute_path(workflows_fixtures_dir):
+    gold_image_path = f"{workflows_fixtures_dir}/images/000001-32.600.2.tif"
+    return gold_image_path

--- a/tests/test_nautilus_librarian/test_typer/test_commands/test_workflows/test_actions/test_dvc_pull_action.py
+++ b/tests/test_nautilus_librarian/test_typer/test_commands/test_workflows/test_actions/test_dvc_pull_action.py
@@ -1,0 +1,58 @@
+import os
+
+from test_nautilus_librarian.test_typer.test_commands.test_workflows.test_gold_images_processing import (
+    copy_media_file_to_its_folder,
+    create_initial_state,
+)
+from test_nautilus_librarian.utils import compact_json
+
+from nautilus_librarian.mods.console.domain.utils import execute_console_command
+from nautilus_librarian.mods.dvc.domain.utils import dvc_diff
+from nautilus_librarian.typer.commands.workflows.actions.dvc_pull_action import (
+    dvc_pull_action,
+)
+
+
+def given_a_dvc_diff_object_with_a_new_gold_image_it_should_pull_the_image_from_the_remote_dvc_storage(
+    temp_git_dir,
+    temp_dvc_local_remote_storage_dir,
+    temp_gpg_home_dir,
+    git_user,
+    sample_gold_image_absolute_path,
+    sample_base_image_absolute_path,
+):
+    remote_name = "localremote"
+
+    create_initial_state(
+        temp_git_dir,
+        temp_dvc_local_remote_storage_dir,
+        sample_base_image_absolute_path,
+        temp_gpg_home_dir,
+        git_user,
+        remote_name,
+    )
+
+    copy_media_file_to_its_folder(sample_gold_image_absolute_path, temp_git_dir)
+
+    # Add the new Gold image and remove the local copy of the image
+    execute_console_command(
+        f"""
+        dvc add data/000001/32/000001-32.600.2.tif
+        dvc push
+        git add data/000001/32/000001-32.600.2.tif.dvc data/000001/32/.gitignore
+        GNUPGHOME={temp_gpg_home_dir} git commit -S --gpg-sign={git_user.signingkey} -m "feat: new gold image: 000001-32.600.2.tif" --author="{git_user.name} <{git_user.email}>" # noqa
+        rm data/000001/32/000001-32.600.2.tif
+    """,
+        cwd=temp_git_dir,
+    )
+
+    dvc_diff_dict = dvc_diff("HEAD^", "HEAD", temp_git_dir)
+
+    # Assert Gold image does not exist
+    assert not os.path.exists(f"{temp_git_dir}/data/000001/32/000001-32.600.2.tif")
+
+    # We pull the Gold image from the local remote storage
+    dvc_pull_action(compact_json(dvc_diff_dict), str(temp_git_dir), remote_name)
+
+    # Assert Gold image was pulled from the local remote storage
+    assert os.path.isfile(f"{temp_git_dir}/data/000001/32/000001-32.600.2.tif")

--- a/tests/test_nautilus_librarian/test_typer/test_commands/test_workflows/test_gold_images_processing.py
+++ b/tests/test_nautilus_librarian/test_typer/test_commands/test_workflows/test_gold_images_processing.py
@@ -1,3 +1,4 @@
+import os
 from shutil import copy
 
 from test_nautilus_librarian.utils import compact_json
@@ -6,9 +7,28 @@ from typer.testing import CliRunner
 from nautilus_librarian.domain.file_locator import file_locator
 from nautilus_librarian.main import app
 from nautilus_librarian.mods.console.domain.utils import execute_console_command
+from nautilus_librarian.mods.dvc.domain.utils import dvc_diff
 from nautilus_librarian.mods.namecodes.domain.filename import Filename
 
 runner = CliRunner()
+
+
+def assert_expected_output(output, expected_output):
+    """
+    It removes the indentation from the expected output because the real output does not have indentation.
+    """
+    lines = expected_output.splitlines()
+
+    # Remove first line break
+    lines.pop(0)
+
+    # Remove indentation
+    lines_without_indent = [line.strip() for line in lines]
+
+    # Join the string back
+    expected_output_without_indent = "\n".join(lines_without_indent)
+
+    assert output == expected_output_without_indent
 
 
 def create_initial_state(
@@ -17,6 +37,7 @@ def create_initial_state(
     sample_base_image_absolute_path,
     temp_gpg_home_dir,
     git_user,
+    remote_name="localremote",
 ):
     """
     Helper function to create the initial state needed to test the workflow.
@@ -36,7 +57,7 @@ def create_initial_state(
         dvc init
         git add -A
         GNUPGHOME={temp_gpg_home_dir} git commit -S --gpg-sign={git_user.signingkey} -m "dvc init" --author="{git_user.name} <{git_user.email}>" # noqa
-        dvc remote add -d localremote {temp_dvc_local_remote_storage_dir}
+        dvc remote add -d {remote_name} {temp_dvc_local_remote_storage_dir}
         git add -A
         GNUPGHOME={temp_gpg_home_dir} git commit -S --gpg-sign={git_user.signingkey} -m "dvc add remote" --author="{git_user.name} <{git_user.email}>" # noqa
         mkdir -p {sample_base_image_dir}
@@ -46,6 +67,21 @@ def create_initial_state(
 
     # Copy the Base sample Base image to its folder
     copy(sample_base_image_absolute_path, f"{temp_git_dir}/{sample_base_image_dir}")
+
+
+def copy_media_file_to_its_folder(src_media_file_path, git_dir):
+    """
+    Given a library file in a source location, it copies it to the git repo in the right folder.
+    """
+
+    media_file_relative_dir = file_locator(Filename(src_media_file_path))
+
+    dest_media_file_dir = f"{git_dir}/{media_file_relative_dir}"
+
+    # Create dest dir if it does not exist
+    os.makedirs(dest_media_file_dir, exist_ok=True)
+
+    copy(src_media_file_path, dest_media_file_dir)
 
 
 def it_should_show_a_message_if_there_is_not_any_change_in_gold_images():
@@ -58,6 +94,7 @@ def it_should_show_a_message_if_there_is_not_any_change_in_gold_images():
 def test_gold_images_processing_workflow_command(
     temp_git_dir,
     temp_dvc_local_remote_storage_dir,
+    sample_gold_image_absolute_path,
     sample_base_image_absolute_path,
     temp_gpg_home_dir,
     git_user,
@@ -74,18 +111,24 @@ def test_gold_images_processing_workflow_command(
         git_user,
     )
 
-    dvc_diff = {
-        "added": [
-            {"path": "data/000001/32/000001-32.600.2.tif"},
-        ],
-        "deleted": [],
-        "modified": [],
-        "renamed": [],
-    }
+    copy_media_file_to_its_folder(sample_gold_image_absolute_path, temp_git_dir)
+
+    # Add the new Gold image
+    execute_console_command(
+        f"""
+        dvc add data/000001/32/000001-32.600.2.tif
+        dvc push
+        git add data/000001/32/000001-32.600.2.tif.dvc data/000001/32/.gitignore
+        GNUPGHOME={temp_gpg_home_dir} git commit -S --gpg-sign={git_user.signingkey} -m "feat: new gold image: 000001-32.600.2.tif" --author="{git_user.name} <{git_user.email}>" # noqa
+    """,
+        cwd=temp_git_dir,
+    )
+
+    dvc_diff_dict = dvc_diff("HEAD^", "HEAD", temp_git_dir)
 
     result = runner.invoke(
         app,
-        ["gold-images-processing", compact_json(dvc_diff)],
+        ["gold-images-processing", compact_json(dvc_diff_dict)],
         env={
             "INPUT_GIT_REPO_DIR": str(temp_git_dir),
             "INPUT_GIT_USER_NAME": git_user.name,
@@ -96,7 +139,12 @@ def test_gold_images_processing_workflow_command(
     )
 
     assert result.exit_code == 0
-    assert (
-        "000001-32.600.2.tif ✓\nNew Gold image found: 000001-32.600.2.tif -> Base image: data/000001/42/000001-42.600.2.tif ✓ \n"  # noqa
-        in result.stdout
-    )
+
+    expected_output = """
+    000001-32.600.2.tif ✓
+    data/000001/32/000001-32.600.2.tif ✓
+    ✓ data/000001/32/000001-32.600.2.tif pulled from dvc storage
+    New Gold image found: 000001-32.600.2.tif -> Base image: data/000001/42/000001-42.600.2.tif ✓
+    """
+
+    assert_expected_output(result.stdout, expected_output)


### PR DESCRIPTION
I have migrated another step more. This new action/step replaces the old shell embedded action:

```
- name: Pull images from remote storage
  env:
    AZURE_STORAGE_ACCOUNT: ${{ secrets.AZURE_STORAGE_ACCOUNT }}
    AZURE_STORAGE_SAS_TOKEN: ${{ secrets.AZURE_STORAGE_SAS_TOKEN }}
  run: dvc pull --remote azure
```

in the [library](https://github.com/Nautilus-Cyberneering/chinese-ideographs/blob/main/.github/workflows/gold-drawings-processing.yml#L44-L48).

There are two things to refactor **after** the merge:

1. Remove deprecated DVC functions. Now we have the DVD API wrapper and we can use it even in our tests instead of running the command. I found a cool package to mark functions as deprecated. It even shows you a warning when you execute the tests.
2. As I was discussing with @yeraydavidrodriguez this morning we have to refactor some test helpers, especially the builder to create the initial state before running the tests (`create_initial_state`). We think we could use a builder to arrange the initial state of the tests.