### PR TITLE
Refactor: extract class DvcDiffParser

### DIFF
--- a/src/nautilus_librarian/mods/dvc/domain/dvc_diff_parser.py
+++ b/src/nautilus_librarian/mods/dvc/domain/dvc_diff_parser.py
@@ -1,0 +1,79 @@
+import json
+import os
+
+
+class DvcDiffParser:
+    def __init__(self, dvc_diff: dict) -> None:
+        self.dvc_diff = dvc_diff
+        self.added_list = None
+        self.deleted_list = None
+        self.modified_list = None
+        self.renamed_list = None
+        self.parse()
+
+    @staticmethod
+    def from_json(dvc_diff):
+        return DvcDiffParser(json.loads(dvc_diff))
+
+    def parse(self):
+        self.added_list = [element["path"] for element in self.dvc_diff["added"]]
+        self.deleted_list = [element["path"] for element in self.dvc_diff["deleted"]]
+        self.modified_list = [element["path"] for element in self.dvc_diff["modified"]]
+        self.renamed_list = [element["path"] for element in self.dvc_diff["renamed"]]
+
+    def basename_of(self, filepath: str) -> str:
+        return os.path.basename(filepath)
+
+    def basenames_of(self, filepaths: list[str]) -> list[str]:
+        return [self.basename_of(filepath) for filepath in filepaths]
+
+    def added(self, only_basename=False):
+        if only_basename:
+            return self.basenames_of(self.added_list)
+
+        return self.added_list
+
+    def deleted(self, only_basename=False):
+        if only_basename:
+            return self.basenames_of(self.deleted_list)
+
+        return self.deleted_list
+
+    def modified(self, only_basename=False):
+        if only_basename:
+            return self.basenames_of(self.modified_list)
+
+        return self.modified_list
+
+    def renamed(self, only_basename=False):
+        if only_basename:
+            return self.basenames_of(self.renamed_list)
+
+        return self.renamed_list
+
+    def filter(
+        self,
+        exclude_added=False,
+        exclude_deleted=False,
+        exclude_modified=False,
+        exclude_renamed=False,
+        only_basename=False,
+    ):
+        files = []
+
+        if not exclude_added:
+            files = files + self.added_list
+
+        if not exclude_deleted:
+            files = files + self.deleted_list
+
+        if not exclude_modified:
+            files = files + self.modified_list
+
+        if not exclude_renamed:
+            files = files + self.renamed_list
+
+        if only_basename:
+            return self.basenames_of(files)
+
+        return files

--- a/tests/test_nautilus_librarian/test_mods/test_dvc/test_domain/test_dvc_diff_parser.py
+++ b/tests/test_nautilus_librarian/test_mods/test_dvc/test_domain/test_dvc_diff_parser.py
@@ -1,0 +1,226 @@
+import json
+
+from nautilus_librarian.mods.dvc.domain.dvc_diff_parser import DvcDiffParser
+
+
+def test_dvc_diff_parser_initialization():
+
+    dvc_diff = DvcDiffParser(
+        {
+            "added": [],
+            "deleted": [],
+            "modified": [],
+            "renamed": [],
+        }
+    )
+
+    assert isinstance(dvc_diff, DvcDiffParser)
+
+
+def test_dvc_diff_parser_instantiation_from_json():
+
+    dvc_diff_dict = {
+        "added": [],
+        "deleted": [],
+        "modified": [],
+        "renamed": [],
+    }
+
+    dvc_diff = DvcDiffParser.from_json(json.dumps(dvc_diff_dict))
+
+    assert isinstance(dvc_diff, DvcDiffParser)
+
+
+def it_should_get_the_added_files():
+
+    dvc_diff = DvcDiffParser(
+        {
+            "added": [
+                {"path": "folder/added_file.txt"},
+            ],
+            "deleted": [],
+            "modified": [],
+            "renamed": [],
+        }
+    )
+
+    added = dvc_diff.added()
+
+    assert added == ["folder/added_file.txt"]
+
+
+def it_should_get_only_the_basenames_of_the_added_files():
+
+    dvc_diff = DvcDiffParser(
+        {
+            "added": [
+                {"path": "folder/added_file.txt"},
+            ],
+            "deleted": [],
+            "modified": [],
+            "renamed": [],
+        }
+    )
+
+    added = dvc_diff.added(only_basename=True)
+
+    assert added == ["added_file.txt"]
+
+
+def it_should_get_the_deleted_files():
+
+    dvc_diff = DvcDiffParser(
+        {
+            "added": [],
+            "deleted": [
+                {"path": "folder/deleted_file.txt"},
+            ],
+            "modified": [],
+            "renamed": [],
+        }
+    )
+
+    added = dvc_diff.deleted()
+
+    assert added == ["folder/deleted_file.txt"]
+
+
+def it_should_get_only_the_basenames_of_the_deleted_files():
+
+    dvc_diff = DvcDiffParser(
+        {
+            "added": [],
+            "deleted": [
+                {"path": "folder/deleted_file.txt"},
+            ],
+            "modified": [],
+            "renamed": [],
+        }
+    )
+
+    added = dvc_diff.deleted(only_basename=True)
+
+    assert added == ["deleted_file.txt"]
+
+
+def it_should_get_the_modified_files():
+
+    dvc_diff = DvcDiffParser(
+        {
+            "added": [],
+            "deleted": [],
+            "modified": [
+                {"path": "folder/modified_file.txt"},
+            ],
+            "renamed": [],
+        }
+    )
+
+    added = dvc_diff.modified()
+
+    assert added == ["folder/modified_file.txt"]
+
+
+def it_should_get_only_the_basenames_of_the_modified_files():
+
+    dvc_diff = DvcDiffParser(
+        {
+            "added": [],
+            "deleted": [],
+            "modified": [
+                {"path": "folder/modified_file.txt"},
+            ],
+            "renamed": [],
+        }
+    )
+
+    added = dvc_diff.modified(only_basename=True)
+
+    assert added == ["modified_file.txt"]
+
+
+def it_should_get_the_renamed_files():
+
+    dvc_diff = DvcDiffParser(
+        {
+            "added": [],
+            "deleted": [],
+            "modified": [],
+            "renamed": [
+                {"path": "folder/renamed_file.txt"},
+            ],
+        }
+    )
+
+    added = dvc_diff.renamed()
+
+    assert added == ["folder/renamed_file.txt"]
+
+
+def it_should_get_only_the_basenames_of_the_renamed_files():
+
+    dvc_diff = DvcDiffParser(
+        {
+            "added": [],
+            "deleted": [],
+            "modified": [],
+            "renamed": [
+                {"path": "folder/renamed_file.txt"},
+            ],
+        }
+    )
+
+    added = dvc_diff.renamed(only_basename=True)
+
+    assert added == ["renamed_file.txt"]
+
+
+def it_should_filter_by_type_of_change():
+
+    dvc_diff = DvcDiffParser(
+        {
+            "added": [
+                {"path": "folder/added_file.txt"},
+            ],
+            "deleted": [
+                {"path": "folder/deleted_file.txt"},
+            ],
+            "modified": [
+                {"path": "folder/modified_file.txt"},
+            ],
+            "renamed": [
+                {"path": "folder/renamed_file.txt"},
+            ],
+        }
+    )
+
+    assert dvc_diff.filter() == [
+        "folder/added_file.txt",
+        "folder/deleted_file.txt",
+        "folder/modified_file.txt",
+        "folder/renamed_file.txt",
+    ]
+
+    assert dvc_diff.filter(exclude_added=True) == [
+        "folder/deleted_file.txt",
+        "folder/modified_file.txt",
+        "folder/renamed_file.txt",
+    ]
+
+    assert dvc_diff.filter(exclude_deleted=True) == [
+        "folder/added_file.txt",
+        "folder/modified_file.txt",
+        "folder/renamed_file.txt",
+    ]
+
+    assert dvc_diff.filter(exclude_modified=True) == [
+        "folder/added_file.txt",
+        "folder/deleted_file.txt",
+        "folder/renamed_file.txt",
+    ]
+
+    assert dvc_diff.filter(exclude_renamed=True) == [
+        "folder/added_file.txt",
+        "folder/deleted_file.txt",
+        "folder/modified_file.txt",
+    ]


### PR DESCRIPTION
I've added a small class to extract data from the DVC diff output:

For example, from this json:

```json
{
    "added": [],
    "deleted": [],
    "modified": [],
    "renamed": [],
}
```

You can get only the `added` files with:

```
dvc_diff = DvcDiffParser.from_json(dvc_diff_json)
return dvc_diff.filter(
    exclude_deleted=True, exclude_modified=True, exclude_renamed=True
)
```

I was not sure if I should do the opposite:

```
dvc_diff = DvcDiffParser.from_json(dvc_diff_json)
return dvc_diff.filter(
    include_added=True
)
```

But then, I thought I should rename the method to:

```
return dvc_diff.extract(
    include_added=True
)
```

Because I would expect `filter` to remove items from the list of all files.