### PR TITLE
First gold image processing action implementation

### DIFF
--- a/src/nautilus_librarian/mods/libvips/domain/process_image.py
+++ b/src/nautilus_librarian/mods/libvips/domain/process_image.py
@@ -1,0 +1,15 @@
+from nautilus_librarian.mods.libvips.domain.utils import get_image, resample_image, save_image
+import os
+
+def create_output_folder(destination_filename):
+    os.makedirs(os.path.dirname(destination_filename), exist_ok=True)
+
+def process_image(filename, destination_filename: str, base_image_size: int):
+    """
+    Generates and saves an image file using a source image, with the specified size
+    """
+    image = get_image(filename)
+    image = resample_image(image, base_image_size)
+    create_output_folder(destination_filename)
+    save_image(image, destination_filename)
+

--- a/src/nautilus_librarian/mods/libvips/domain/utils.py
+++ b/src/nautilus_librarian/mods/libvips/domain/utils.py
@@ -1,6 +1,26 @@
 import pyvips
 
 
+def get_image(source_image_path):
+    return pyvips.Image.new_from_file(source_image_path, access="sequential")
+
+
+def get_image_resizing_factor(image, output_size):
+    width = image.width
+    height = image.height
+    factor_width = output_size / width
+    factor_height = output_size / height
+    return min(factor_height, factor_width)
+
+
+def save_image(image, destination_image_path):
+    image.write_to_file(destination_image_path)
+
+
+def resample_image(image, size):
+    return image.resize(get_image_resizing_factor(image, size), kernel='lanczos2')
+
+
 def get_image_dimensions(source_image_path):
-    image = pyvips.Image.new_from_file(source_image_path, access="sequential")
+    image = get_image(source_image_path)
     return image.width, image.height

--- a/src/nautilus_librarian/typer/commands/workflows/actions/generate_base_images_action.py
+++ b/src/nautilus_librarian/typer/commands/workflows/actions/generate_base_images_action.py
@@ -1,0 +1,56 @@
+from nautilus_librarian.domain.file_locator import file_locator
+from nautilus_librarian.mods.dvc.domain.utils import (
+    extract_list_of_media_file_changes_from_dvc_diff_output,
+)
+from nautilus_librarian.mods.libvips.domain.process_image import (
+    process_image,
+)
+from nautilus_librarian.mods.namecodes.domain.filename import Filename
+from nautilus_librarian.typer.commands.workflows.actions.action_result import (
+    ActionResult,
+    ErrorMessage,
+    Message,
+    ResultCode,
+)
+
+
+def get_base_image_absolute_path(git_repo_dir, gold_image):
+    corresponding_base_image = gold_image.generate_base_image_filename()
+    corresponding_base_image_relative_path = (
+        file_locator(corresponding_base_image) + "/" + str(corresponding_base_image)
+    )
+    return (
+        git_repo_dir + "/" + corresponding_base_image_relative_path
+    )
+
+
+def generate_base_images(dvc_diff, git_repo_dir, base_images_size):
+    """
+    It generates the base images of all the media sizes in the dvc diff.
+    """
+    if dvc_diff == "{}":
+        return ActionResult(ResultCode.EXIT, [Message("No Gold image changes found")])
+
+    filenames = extract_list_of_media_file_changes_from_dvc_diff_output(
+        dvc_diff, only_basename=False
+    )
+
+    messages = []
+
+    for filename in filenames:
+        try:
+            gold_filename = Filename(filename)
+            base_filename = get_base_image_absolute_path(git_repo_dir, gold_filename)
+            process_image(
+                f"{git_repo_dir}/{filename}", f"{base_filename}", base_images_size
+            )
+            messages.append(
+                Message(f"✓ Base image of {filename} sucessfully generated")
+            )
+        except ValueError as error:
+            return ActionResult(
+                ResultCode.ABORT,
+                [ErrorMessage(f"✗ Error generating base image of {filename}: {error}")],
+            )
+
+    return ActionResult(ResultCode.CONTINUE, messages)

--- a/src/nautilus_librarian/typer/commands/workflows/gold_images_processing.py
+++ b/src/nautilus_librarian/typer/commands/workflows/gold_images_processing.py
@@ -18,12 +18,15 @@ from nautilus_librarian.typer.commands.workflows.actions.dvc_pull_action import 
 from nautilus_librarian.typer.commands.workflows.actions.validate_filenames import (
     validate_filenames,
 )
+from nautilus_librarian.typer.commands.workflows.actions.generate_base_images_action import (
+    generate_base_images,
+)
 from nautilus_librarian.typer.commands.workflows.actions.validate_filepaths_action import (
     validate_filepaths_action,
 )
 from nautilus_librarian.typer.commands.workflows.actions.validate_images_dimensions_action import (
     validate_images_dimensions,
-)
+)   
 
 app = typer.Typer()
 
@@ -64,6 +67,7 @@ def gold_images_processing(
     ),
     min_image_size: int = typer.Option(256, envvar="NL_MIN_IMAGE_SIZE"),
     max_image_size: int = typer.Option(16384, envvar="NL_MAX_IMAGE_SIZE"),
+    base_image_size: int = typer.Option(512, envvar="NL_BASE_IMAGE_SIZE"),
     dvc_diff: str = typer.Option(None, envvar="NL_DVC_DIFF"),
     previous_ref: str = typer.Option("HEAD", envvar="NL_PREVIOUS_REF"),
     current_ref: str = typer.Option(None, envvar="NL_CURRENT_REF"),
@@ -115,6 +119,10 @@ def gold_images_processing(
 
     process_action_result(
         validate_images_dimensions(dvc_diff, min_image_size, max_image_size)
+    )
+
+    process_action_result(
+        generate_base_images(dvc_diff, git_repo_dir, base_image_size)
     )
 
     process_action_result(


### PR DESCRIPTION
This Pull Request implements [Issue 71](https://github.com/Nautilus-Cyberneering/nautilus-librarian/issues/71): Image processing action.

This action will:

- Open the Gold Images reported in the DVC
- Resize them according to a command line option
- Change its ICC profile
- Save them using the appropiate base image path + name
