### PR TITLE
Add installation instructions to publishing workflows

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -21,6 +21,12 @@ jobs:
         with:
           python-version: "3.9"
 
+      - name: Setup Libvips
+        run: |
+          sudo apt-get update
+          sudo apt-get upgrade -y
+          sudo apt-get install -y libvips-dev
+
       - name: Setup Poetry
         run: pip3 install poetry poetry-dynamic-versioning
 

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -71,4 +71,3 @@ jobs:
           images: |
             nautiluscyberneering/librarian
             ghcr.io/${{ github.repository }}
-

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -4,7 +4,7 @@ on:
   push:
     tags:
       - "*.*.*"
-  workflow_dispatch
+  workflow_dispatch:
 
 jobs:
   build:
@@ -72,10 +72,3 @@ jobs:
             nautiluscyberneering/librarian
             ghcr.io/${{ github.repository }}
 
-      - name: Build and push Docker images
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "*.*.*"
+  workflow_dispatch
 
 jobs:
   build:

--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -20,6 +20,12 @@ jobs:
         with:
           python-version: "3.9"
 
+      - name: Setup Libvips
+        run: |
+          sudo apt-get update
+          sudo apt-get upgrade -y
+          sudo apt-get install -y libvips-dev
+
       - name: Setup Poetry
         run: pip3 install poetry poetry-dynamic-versioning
 

--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -4,7 +4,7 @@ on:
   push:
     tags:
       - "*.*.*"
-  workflow_dispatch
+  workflow_dispatch:
 
 jobs:
   build:
@@ -59,10 +59,3 @@ jobs:
           [[ "$(poetry version --short)" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
             || echo ::set-output name=prerelease::true
 
-      - name: Create Release
-        uses: ncipollo/release-action@v1
-        with:
-          artifacts: "dist/*"
-          token: ${{ secrets.GITHUB_TOKEN }}
-          draft: false
-          prerelease: steps.check-version.outputs.prerelease == 'true'

--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -58,4 +58,3 @@ jobs:
         run: |
           [[ "$(poetry version --short)" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
             || echo ::set-output name=prerelease::true
-

--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "*.*.*"
+  workflow_dispatch
 
 jobs:
   build:

--- a/.github/workflows/publish-pypi-package.yml
+++ b/.github/workflows/publish-pypi-package.yml
@@ -50,4 +50,3 @@ jobs:
 
       - name: Build Python package
         run: poetry build
-

--- a/.github/workflows/publish-pypi-package.yml
+++ b/.github/workflows/publish-pypi-package.yml
@@ -4,7 +4,7 @@ on:
   push:
     tags:
       - "*.*.*"
-  workflow_dispatch
+  workflow_dispatch:
 
 jobs:
   build:
@@ -51,7 +51,3 @@ jobs:
       - name: Build Python package
         run: poetry build
 
-      - name: Publish to PyPI
-        env:
-          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_API_TOKEN }}
-        run: poetry publish

--- a/.github/workflows/publish-pypi-package.yml
+++ b/.github/workflows/publish-pypi-package.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "*.*.*"
+  workflow_dispatch
 
 jobs:
   build:

--- a/.github/workflows/publish-pypi-package.yml
+++ b/.github/workflows/publish-pypi-package.yml
@@ -18,6 +18,12 @@ jobs:
         with:
           python-version: "3.9"
 
+      - name: Setup Libvips
+        run: |
+          sudo apt-get update
+          sudo apt-get upgrade -y
+          sudo apt-get install -y libvips-dev
+
       - name: Setup Poetry
         run: pip3 install poetry poetry-dynamic-versioning
 

--- a/src/nautilus_librarian/typer/commands/workflows/actions/auto_commit_base_images.py
+++ b/src/nautilus_librarian/typer/commands/workflows/actions/auto_commit_base_images.py
@@ -1,11 +1,11 @@
 import os
 from typing import List
 
+from nautilus_librarian.domain.dvc_services_api import DvcServicesApi
 from nautilus_librarian.domain.file_locator import (
     file_locator,
     guard_that_base_image_exists,
 )
-from nautilus_librarian.domain.dvc_services_api import DvcServicesApi
 from nautilus_librarian.mods.dvc.domain.utils import (
     extract_added_files_from_dvc_diff,
     extract_deleted_files_from_dvc_diff,

--- a/src/nautilus_librarian/typer/commands/workflows/actions/delete_base_images_action.py
+++ b/src/nautilus_librarian/typer/commands/workflows/actions/delete_base_images_action.py
@@ -1,7 +1,7 @@
 from os import path, remove
 
-from nautilus_librarian.domain.file_locator import file_locator
 from nautilus_librarian.domain.dvc_services_api import DvcServicesApi
+from nautilus_librarian.domain.file_locator import file_locator
 from nautilus_librarian.mods.dvc.domain.utils import extract_deleted_files_from_dvc_diff
 from nautilus_librarian.mods.namecodes.domain.filename import Filename
 from nautilus_librarian.typer.commands.workflows.actions.action_result import (

--- a/src/nautilus_librarian/typer/commands/workflows/actions/generate_base_images_action.py
+++ b/src/nautilus_librarian/typer/commands/workflows/actions/generate_base_images_action.py
@@ -1,5 +1,5 @@
-from nautilus_librarian.domain.file_locator import file_locator
 from nautilus_librarian.domain.dvc_services_api import DvcServicesApi
+from nautilus_librarian.domain.file_locator import file_locator
 from nautilus_librarian.mods.dvc.domain.utils import (
     extract_added_and_modified_files_from_dvc_diff,
 )

--- a/src/nautilus_librarian/typer/commands/workflows/actions/rename_base_images_action.py
+++ b/src/nautilus_librarian/typer/commands/workflows/actions/rename_base_images_action.py
@@ -1,10 +1,10 @@
 from os import makedirs, path
 
+from nautilus_librarian.domain.dvc_services_api import DvcServicesApi
 from nautilus_librarian.domain.file_locator import (
     get_base_image_absolute_path,
     guard_that_base_image_exists,
 )
-from nautilus_librarian.domain.dvc_services_api import DvcServicesApi
 from nautilus_librarian.mods.dvc.domain.utils import extract_renamed_files_from_dvc_diff
 from nautilus_librarian.mods.namecodes.domain.filename import Filename
 from nautilus_librarian.typer.commands.workflows.actions.action_result import (

--- a/src/nautilus_librarian/typer/commands/workflows/gold_images_processing.py
+++ b/src/nautilus_librarian/typer/commands/workflows/gold_images_processing.py
@@ -1,7 +1,7 @@
 import typer
 
-from nautilus_librarian.mods.console.domain.utils import get_current_working_directory
 from nautilus_librarian.domain.dvc_services_api import DvcServicesApi
+from nautilus_librarian.mods.console.domain.utils import get_current_working_directory
 from nautilus_librarian.mods.git.domain.config import (
     default_git_user_email,
     default_git_user_name,

--- a/tests/test_nautilus_librarian/test_mods/test_dvc/test_domain/test_dvc_services_api.py
+++ b/tests/test_nautilus_librarian/test_mods/test_dvc/test_domain/test_dvc_services_api.py
@@ -7,9 +7,9 @@ from os import path
 import pytest
 from git import Repo
 
+from nautilus_librarian.domain.dvc_services_api import DvcServicesApi
 from nautilus_librarian.mods.dvc.domain.api import DvcApiWrapper
 from nautilus_librarian.mods.dvc.domain.dvc_command_wrapper import dvc
-from nautilus_librarian.domain.dvc_services_api import DvcServicesApi
 
 
 def create_librarian_test_contents(temp_dir):


### PR DESCRIPTION
This PR will add the shell commands needed to install Libvips depedency on the three publishing workflows

Resolves #86 