### PR TITLE
Fix Git and GPG credentials being injected in the publishing workflows

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - "*.*.*"
-  workflow_dispatch:
 
 jobs:
   build:
@@ -86,3 +85,11 @@ jobs:
           images: |
             nautiluscyberneering/librarian
             ghcr.io/${{ github.repository }}
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -24,12 +24,7 @@ jobs:
           passphrase: ${{ secrets.TEST_PASSPHRASE }}
           git_user_signingkey: true
           git_commit_gpgsign: true
-
-      - name: Set GPG key user as the Git global user
-        run: |
-          git config --global user.email "${{ steps.import-gpg.outputs.email }}"
-          git config --global user.name "${{ steps.import-gpg.outputs.name }}"
-          git config --global user.signingkey "${{ steps.import-gpg.outputs.keyid }}"
+          git_config_global: true
 
       - name: Setup Python
         uses: actions/setup-python@v2.3.1

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -17,6 +17,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Import GPG key used for testing
+        id: import-gpg
+        uses: crazy-max/ghaction-import-gpg@v4
+        with:
+          gpg_private_key: ${{ secrets.TEST_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.TEST_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
+      - name: Set GPG key user as the Git global user
+        run: |
+          git config --global user.email "${{ steps.import-gpg.outputs.email }}"
+          git config --global user.name "${{ steps.import-gpg.outputs.name }}"
+          git config --global user.signingkey "${{ steps.import-gpg.outputs.keyid }}"
+
       - name: Setup Python
         uses: actions/setup-python@v2.3.1
         with:

--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -23,12 +23,7 @@ jobs:
           passphrase: ${{ secrets.TEST_PASSPHRASE }}
           git_user_signingkey: true
           git_commit_gpgsign: true
-
-      - name: Set GPG key user as the Git global user
-        run: |
-          git config --global user.email "${{ steps.import-gpg.outputs.email }}"
-          git config --global user.name "${{ steps.import-gpg.outputs.name }}"
-          git config --global user.signingkey "${{ steps.import-gpg.outputs.keyid }}"
+          git_config_global: true
 
       - name: Setup Python
         uses: actions/setup-python@v2.3.1

--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - "*.*.*"
-  workflow_dispatch:
 
 jobs:
   build:
@@ -73,3 +72,11 @@ jobs:
         run: |
           [[ "$(poetry version --short)" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
             || echo ::set-output name=prerelease::true
+
+      - name: Create Release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "dist/*"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          draft: false
+          prerelease: steps.check-version.outputs.prerelease == 'true'

--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -16,6 +16,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Import GPG key used for testing
+        id: import-gpg
+        uses: crazy-max/ghaction-import-gpg@v4
+        with:
+          gpg_private_key: ${{ secrets.TEST_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.TEST_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
+      - name: Set GPG key user as the Git global user
+        run: |
+          git config --global user.email "${{ steps.import-gpg.outputs.email }}"
+          git config --global user.name "${{ steps.import-gpg.outputs.name }}"
+          git config --global user.signingkey "${{ steps.import-gpg.outputs.keyid }}"
+
       - name: Setup Python
         uses: actions/setup-python@v2.3.1
         with:

--- a/.github/workflows/publish-pypi-package.yml
+++ b/.github/workflows/publish-pypi-package.yml
@@ -14,6 +14,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Import GPG key used for testing
+        id: import-gpg
+        uses: crazy-max/ghaction-import-gpg@v4
+        with:
+          gpg_private_key: ${{ secrets.TEST_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.TEST_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
+      - name: Set GPG key user as the Git global user
+        run: |
+          git config --global user.email "${{ steps.import-gpg.outputs.email }}"
+          git config --global user.name "${{ steps.import-gpg.outputs.name }}"
+          git config --global user.signingkey "${{ steps.import-gpg.outputs.keyid }}"
+
       - name: Setup Python
         uses: actions/setup-python@v2.3.1
         with:

--- a/.github/workflows/publish-pypi-package.yml
+++ b/.github/workflows/publish-pypi-package.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - "*.*.*"
-  workflow_dispatch:
 
 jobs:
   build:
@@ -65,3 +64,8 @@ jobs:
 
       - name: Build Python package
         run: poetry build
+
+      - name: Publish to PyPI
+        env:
+          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_API_TOKEN }}
+        run: poetry publish

--- a/.github/workflows/publish-pypi-package.yml
+++ b/.github/workflows/publish-pypi-package.yml
@@ -21,12 +21,7 @@ jobs:
           passphrase: ${{ secrets.TEST_PASSPHRASE }}
           git_user_signingkey: true
           git_commit_gpgsign: true
-
-      - name: Set GPG key user as the Git global user
-        run: |
-          git config --global user.email "${{ steps.import-gpg.outputs.email }}"
-          git config --global user.name "${{ steps.import-gpg.outputs.name }}"
-          git config --global user.signingkey "${{ steps.import-gpg.outputs.keyid }}"
+          git_config_global: true
 
       - name: Setup Python
         uses: actions/setup-python@v2.3.1


### PR DESCRIPTION
A error regarding Git identification was being thrown after the dependency error fix on the publishing workflows.

This pull request fixes this new error, re-enables publishing steps (previously disabled for testing purposes) and removes trigger event from the workflows.